### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "dialog-polyfill",
+  "main": ["dialog-polyfill.js", "dialog-polyfill.css"],
+  "version": "0.1.0",
+  "homepage": "https://github.com/GoogleChrome/dialog-polyfill",
+  "authors": [
+    "The Chromium Authors"
+  ],
+  "description": "Polyfill for the <dialog> element",
+  "keywords": [
+    "html5",
+    "polyfill",
+    "dialog"
+  ],
+  "license": "BSD",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Allows to use bower to install the package:
- `bower install GoogleChrome/dialog-polyfill`
- or `bower install dialog-polyfill` once the package is registered.
