### PR TITLE
Added "close" event triggering and returnValue

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -99,7 +99,7 @@ dialogPolyfill.close = function(retval) {
   var event;
   if (document.createEvent) {
     event = document.createEvent('HTMLEvents');
-    event.initEvent('close',true,true);
+    event.initEvent('close', true, true);
   } else {
     event = new Event('close');
   }


### PR DESCRIPTION
- added "close" event triggering for any attached listeners on the
  <dialog> element
- set returnValue on the element if provided as argument for the close()
  method

as per spec
http://www.whatwg.org/specs/web-apps/current-work/multipage/commands.html#the-dialog-element
