### PR TITLE
set and clear the open attribute

### DIFF
--- a/dialog-polyfill.css
+++ b/dialog-polyfill.css
@@ -18,6 +18,10 @@ dialog {
   display: none;
 }
 
+dialog[open] {
+  display: block;
+}
+
 .backdrop {
   position: absolute;
   background: rgba(0,0,0,0.1);

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -64,7 +64,6 @@ dialogPolyfill.showDialog = function(isModal) {
   }
   this.open = true;
   this.setAttribute('open', 'open');
-  this.style.display = 'block';
 
   if (dialogPolyfill.needsCentering(this))
     dialogPolyfill.reposition(this);
@@ -79,7 +78,6 @@ dialogPolyfill.close = function(retval) {
     throw new InvalidStateError;
   this.open = false;
   this.removeAttribute('open');
-  this.style.display = 'none';
 
   // Leave returnValue untouched in case it was set directly on the element
   if (typeof retval != 'undefined') {


### PR DESCRIPTION
The spec says that `open` is an attribute. Chrome Canary also sets this attribute.
