### PR TITLE
Add the position of the backdrop

### DIFF
--- a/dialog-polyfill.css
+++ b/dialog-polyfill.css
@@ -25,4 +25,8 @@ dialog[open] {
 .backdrop {
   position: absolute;
   background: rgba(0,0,0,0.1);
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }


### PR DESCRIPTION
Add the position of backdrop to the CSS.
Without the position the backdrop has a width and a height equals to 0 so we can't see it.
