### PR TITLE
ESC key support + 'cancel' event, autofocus, form[type=dialog]

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -88,7 +88,7 @@ var dialogPolyfill = (function() {
             elem.nodeName == 'TEXTAREA')) {
           first_form_ctrl = elem;
         }
-        if (elem.getAttribute('autofocus') === '') {
+        if (elem.autofocus) {
           autofocus = elem;
           return;
         }


### PR DESCRIPTION
- encapsulated entire code
- added `ESC` key support to cancel modal dialog
- fires `cancel` event before `close` on canceling modal dialog
- autofucus
- form[type=dialog]
