### PR TITLE
Add cancelable option for cancel CustomEvent

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -254,7 +254,8 @@ var dialogPolyfill = (function() {
       if (dialog) {
         if (CustomEvent) {
           cancelEvent = new CustomEvent('cancel', {
-            bubbles: false
+            bubbles: false,
+            cancelable: true
           });
         } else {
           cancelEvent = document.createEvent('HTMLEvents');


### PR DESCRIPTION
The cancel event is allowed to do prevent default action to stop the dialog from closing on pressing Esc. 
It is missing the cancelable option from the CustomEvent in cancelDialog() but allowed with the initEvent fallback.
