### PR TITLE
Added cancelable:true to the cancel event.

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -287,7 +287,8 @@ var dialogPolyfill = (function() {
       if (dialog) {
         if (CustomEvent) {
           cancelEvent = new CustomEvent('cancel', {
-            bubbles: false
+            bubbles: false,
+            cancelable: true
           });
         } else {
           cancelEvent = document.createEvent('HTMLEvents');


### PR DESCRIPTION
This way dialog canceling (for example with Esc key) can be `event.preventDefault()`-ed if needed.

Native `<dialog>` implementations (in Chrome for example) allow you to preventDefault the _cancel_ event, and so should the polyfill.

Example usage:

```
dialog.addEventListener("cancel", function (ev) {
    ev.preventDefault();
});
```
