### PR TITLE
Google chrome/dialog polyfill/issues/28

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Fork of https://github.com/GoogleChrome/dialog-polyfill to fix any problems I encounter.
-
 dialog-polyfill.js is a polyfill for `<dialog>`.
 
 `<dialog>` is an element for a popup box in a web page. See


### PR DESCRIPTION
dialogPolyfillInfo is defined on the dialog object, not on DialogManager (fixes issue #28)
