### PR TITLE
Split polyfill and native backdrop css examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ In native `<dialog>`, the backdrop is a pseudo-element:
 When using the polyfill, the backdrop will be an adjacent element:
 
 ```css
-#mydialog + .backdrop,
+#mydialog + .backdrop {
+  background-color: green;
+}
+
 #mydialog::backdrop {
   background-color: green;
 }


### PR DESCRIPTION
Browsers without native support for the backdrop pseudo-element will ignore the entire ruleset as they do not understand the selector.

I realise this is possibly pedantry, so feel free to discard.