### PR TITLE
Add IE 10+ compatibility to supportsCustomEvent

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -1,7 +1,7 @@
 var dialogPolyfill = (function() {
 
   var supportCustomEvent = window.CustomEvent;
-  if (!supportCustomEvent) {
+  if (!supportCustomEvent || typeof supportCustomEvent == "object") {
     supportCustomEvent = function CustomEvent(event, x) {
       x = x || {};
       var ev = document.createEvent('CustomEvent');


### PR DESCRIPTION
The problem on line 4 has to do with the IE 10 implementation of new CustomEvent( ).
The value needs to be one of the predefined values or it will throw a "Object doesn't support this action" error 
document.createEvent("CustomEvent"); - this will work
and then you use
CustomEvent::initCustomEvent() - to define the type as something other than "CustomEvent"
Or for IE 10 just fallback to the IE9 workaround as shown in the PR.