### PR TITLE
Added package.json for npm usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dialog-polyfill",
+  "version": "0.3.0",
+  "description": "Polyfill for the <dialog> element",
+  "main": "dialog-polyfill.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleChrome/dialog-polyfill.git"
+  },
+  "author": "The Chromium Authors",
+  "license": "BSD",
+  "homepage": "https://github.com/GoogleChrome/dialog-polyfill"
+}


### PR DESCRIPTION
I, as well as many others, use npm for front-end package management.  For example, using with webpack.  This would add support for npm.

I would recommend you add this to the npm registry, but that's not strictly necessary.