### PR TITLE
adds dialogPolyfillInfo, a class that encapsulates the dialog behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ When using the polyfill, the backdrop will be an adjacent element:
 ## Limitations
 
 - Modal dialogs have limitations-
-  - The browser's chrome may not be accessible via the tab key
   - They should be a child of `<body>` or have parents without layout (aka, no position `absolute` or `relative` elements)
+  - The browser's chrome may not be accessible via the tab key
   - Stacking can be ruined by playing with z-index
   - Changes to the CSS top/bottom values while open aren't retained
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ This polyfill works on modern versions of all major browsers. It also supports I
   <link rel="stylesheet" type="text/css" href="dialog-polyfill.css" />
 </head>
 <body>
-  <dialog>I'm a dialog!</dialog>
+  <dialog>
+    I'm a dialog!
+    <form method="dialog">
+      <input type="submit" value="Close" />
+    </form>
+  </dialog>
   <script>
     var dialog = document.querySelector('dialog');
     dialogPolyfill.registerDialog(dialog);
@@ -59,11 +64,10 @@ When using the polyfill, the backdrop will be an adjacent element:
 
 ## Limitations
 
-- Modality isn't bulletproof. For example, `accessKey` can be used to focus inert elements.
-  - While focus is inside a `<dialog>`, the browser's chrome cannot be tabbed to.
-- The polyfill `<dialog>` should always be a child of `<body>`.
-- Polyfill top layer stacking can be ruined by playing with z-index.
-- The polyfill `<dialog>` does not retain dynamically set CSS top/bottom values
-upon close.
-- Anchored positioning is not implemented. The native `<dialog>` in Chrome
-doesn't have it either.
+- Modal dialogs have limitations-
+  - The browser's chrome may not be accessible via the tab key
+  - They should be a child of `<body>` or have parents without layout (aka, no position `absolute` or `relative` elements)
+  - Stacking can be ruined by playing with z-index
+  - Changes to the CSS top/bottom values while open aren't retained
+
+- Anchored positioning is not implemented, but the native `<dialog>` in Chrome doesn't have it either

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ When using the polyfill, the backdrop will be an adjacent element:
 
 - Modal dialogs have limitations-
   - They should be a child of `<body>` or have parents without layout (aka, no position `absolute` or `relative` elements)
+  - DOM changes may not correctly clear the top layer, such as when the `<dialog>` is removed from the page
   - The browser's chrome may not be accessible via the tab key
   - Stacking can be ruined by playing with z-index
   - Changes to the CSS top/bottom values while open aren't retained

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -115,9 +115,9 @@
       e.stopPropagation();
     },
 
-    updateZIndex: function(dialogZ, backdropZ) {
-      this.dialog_.style.zIndex = dialogZ;
+    updateZIndex: function(backdropZ, dialogZ) {
       this.backdrop_.style.zIndex = backdropZ;
+      this.dialog_.style.zIndex = dialogZ;
     },
 
     /**

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -27,21 +27,172 @@
     return null;
   }
 
+  /**
+   * @param {!NodeList} nodeList to search
+   * @param {Node} node to find
+   * @return {boolean} whether node is inside nodeList
+   */
+  function inNodeList(nodeList, node) {
+    for (var i = 0; i < nodeList.length; ++i) {
+      if (nodeList[i] == node) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @param {!Element} dialog to upgrade
+   * @constructor
+   */
+  function dialogPolyfillInfo(dialog) {
+    this.dialog_ = dialog;
+    this.open_ = dialog.hasAttribute('open');
+    this.modal_ = false;
+    this.replacedStyleTop_ = false;
+
+    dialog.show = this.show.bind(this, false);
+    dialog.showModal = this.show.bind(this, true);
+    dialog.close = this.close.bind(this);
+
+    Object.defineProperty(dialog, 'open', {
+      set: this.setOpen.bind(this), get: this.getOpen.bind(this)
+    });
+
+    this.backdrop_ = document.createElement('div');
+    this.backdrop_.className = 'backdrop';
+    this.backdropClick_ = this.backdropClick_.bind(this);
+  }
+
+  dialogPolyfillInfo.prototype = {
+
+    /**
+     * @param {boolean} value whether to open or close this dialog
+     */
+    setOpen: function(value) {
+      if (value && !this.open_) {
+        this.show();
+      } else if (!value && this.open_) {
+        this.close();
+      }
+    },
+
+    /**
+     * @return {boolean} whether this dialog is open
+     */
+    getOpen: function() {
+      return this.open_;
+    },
+
+    /**
+     * Handles clicks on the fake .backdrop element, redirecting them as if
+     * they were on the dialog itself.
+     *
+     * @param {!Event} e to redirect
+     */
+    backdropClick_: function(e) {
+      var redirectedEvent = document.createEvent('MouseEvents');
+      redirectedEvent.initMouseEvent(e.type, e.bubbles, e.cancelable, window,
+          e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
+          e.altKey, e.shiftKey, e.metaKey, e.button, e.relatedTarget);
+      this.dialog_.dispatchEvent(redirectedEvent);
+      e.stopPropagation();
+    },
+
+    /**
+     * Shows the dialog.
+     *
+     * @param {boolean=} opt_modal whether to display modal
+     */
+    show: function(opt_modal) {
+      if (this.open_) {
+        throw 'InvalidStateError: showDialog called on open dialog';
+      }
+      this.open_ = true;
+      this.dialog_.setAttribute('open', '');
+      if (opt_modal !== undefined) {
+        this.modal_ = opt_modal;
+      }
+
+      if (this.modal_) {
+        // Insert backdrop.
+        this.backdrop_.addEventListener('click', this.backdropClick_);
+        this.dialog_.parentNode.insertBefore(this.backdrop_,
+            this.dialog_.nextSibling);
+
+        // Find element with `autofocus` attribute or first form control.
+        var target = this.dialog_.querySelector('[autofocus]:not([disabled])');
+        if (!target) {
+          // TODO: technically this is 'any focusable area'
+          var opts = ['button', 'input', 'keygen', 'select', 'textarea'];
+          var query = opts.map(function(el) {
+            return el + ':not([disabled])';
+          }).join(', ');
+          target = this.dialog_.querySelector(query);
+        }
+        document.activeElement && document.activeElement.blur();
+        target && target.focus();
+      }
+
+      if (dialogPolyfill.needsCentering(this.dialog_)) {
+        dialogPolyfill.reposition(this.dialog_);
+        this.replacedStyleTop_ = true;
+      } else {
+        this.replacedStyleTop_ = false;
+      }
+      if (this.modal_) {
+        dialogPolyfill.dm.pushDialog(this.dialog_, this.backdrop_);
+      }
+    },
+
+    /**
+     * Closes this HTMLDialogElement.
+     *
+     * @param {*=} opt_returnValue to use as the returnValue
+     */
+    close: function(opt_returnValue) {
+      if (!this.open_) {
+        throw 'InvalidStateError: close called on closed dialog';
+      }
+      this.open_ = false;
+      this.dialog_.removeAttribute('open');
+
+      // Leave returnValue untouched in case it was set directly on the element
+      if (opt_returnValue !== undefined) {
+        this.dialog_.returnValue = opt_returnValue;
+      }
+
+      // This won't match the native <dialog> exactly because if the user set
+      // top on a centered polyfill dialog, that top gets thrown away when the
+      // dialog is closed. Not sure it's possible to polyfill this perfectly.
+      if (this.replacedStyleTop_) {
+        this.dialog_.style.top = 'auto';
+      }
+
+      if (this.modal_) {
+        this.backdrop_.removeEventListener('click', this.backdropClick_);
+        if (this.backdrop_.parentElement) {
+          this.backdrop_.parentElement.removeChild(this.backdrop_);
+        }
+        dialogPolyfill.dm.removeDialog(this.dialog_);
+      }
+
+      // Triggering "close" event for any attached listeners on the <dialog>.
+      var closeEvent = new supportCustomEvent('close', {
+        bubbles: true,
+        cancelable: false
+      });
+      this.dialog_.dispatchEvent(closeEvent);
+    }
+
+  };
+
   var dialogPolyfill = {};
 
   dialogPolyfill.reposition = function(element) {
     var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
     var topValue = scrollTop + (window.innerHeight - element.offsetHeight) / 2;
     element.style.top = Math.max(0, topValue) + 'px';
-    element.dialogPolyfillInfo.isTopOverridden = true;
-  };
-
-  dialogPolyfill.inNodeList = function(nodeList, node) {
-    for (var i = 0; i < nodeList.length; ++i) {
-      if (nodeList[i] == node)
-        return true;
-    }
-    return false;
   };
 
   dialogPolyfill.isInlinePositionSetByStylesheet = function(element) {
@@ -61,7 +212,7 @@
         try {
           selectedNodes = document.querySelectorAll(rule.selectorText);
         } catch(e) {}
-        if (!selectedNodes || !dialogPolyfill.inNodeList(selectedNodes, element))
+        if (!selectedNodes || !inNodeList(selectedNodes, element))
           continue;
         var cssTop = rule.style.getPropertyValue('top');
         var cssBottom = rule.style.getPropertyValue('bottom');
@@ -88,81 +239,17 @@
     return !dialogPolyfill.isInlinePositionSetByStylesheet(dialog);
   };
 
-  dialogPolyfill.showDialog = function(isModal) {
-    if (this.open) {
-      throw 'InvalidStateError: showDialog called on open dialog';
-    }
-    this.open = true;  // TODO: should be a getter mapped to attribute
-    this.setAttribute('open', 'open');
-
-    if (isModal) {
-      // Find element with `autofocus` attribute or first form control.
-      var target = this.querySelector('[autofocus]:not([disabled])');
-      if (!target) {
-        // TODO: technically this is 'any focusable area'
-        var opts = ['button', 'input', 'keygen', 'select', 'textarea'];
-        var query = opts.map(function(el) {
-          return el + ':not([disabled])';
-        }).join(', ');
-        target = this.querySelector(query);
-      }
-
-      document.activeElement && document.activeElement.blur();
-      target && target.focus();
-    }
-
-    if (dialogPolyfill.needsCentering(this))
-      dialogPolyfill.reposition(this);
-    if (isModal) {
-      this.dialogPolyfillInfo.modal = true;
-      dialogPolyfill.dm.pushDialog(this);
-    }
-  };
-
-  dialogPolyfill.close = function(retval) {
-    if (!this.open && !window.HTMLDialogElement) {
-      // Native implementations will set .open to false, so ignore this error.
-      throw 'InvalidStateError: close called on closed dialog';
-    }
-    this.open = false;
-    this.removeAttribute('open');
-
-    // Leave returnValue untouched in case it was set directly on the element
-    if (typeof retval != 'undefined') {
-      this.returnValue = retval;
-    }
-
-    // This won't match the native <dialog> exactly because if the user sets top
-    // on a centered polyfill dialog, that top gets thrown away when the dialog is
-    // closed. Not sure it's possible to polyfill this perfectly.
-    if (this.dialogPolyfillInfo.isTopOverridden) {
-      this.style.top = 'auto';
-    }
-
-    if (this.dialogPolyfillInfo.modal) {
-      dialogPolyfill.dm.removeDialog(this);
-    }
-
-    // Triggering "close" event for any attached listeners on the <dialog>
-    var closeEvent = new supportCustomEvent('close', {
-      bubbles: true,
-      cancelable: true
-    });
-    this.dispatchEvent(closeEvent);  // TODO: handle cancelling this event
-
-    return this.returnValue;
-  };
-
+  /**
+   * @export
+   * @param {!Element} element upgrade
+   */
   dialogPolyfill.registerDialog = function(element) {
     if (element.show) {
       console.warn("This browser already supports <dialog>, the polyfill " +
           "may not work correctly.");
     }
-    element.show = dialogPolyfill.showDialog.bind(element, false);
-    element.showModal = dialogPolyfill.showDialog.bind(element, true);
-    element.close = dialogPolyfill.close.bind(element);
-    element.dialogPolyfillInfo = {};
-    element.open = false;
+    var pfi = new dialogPolyfillInfo(element);
+    // TODO: ?
   };
 
   // The overlay is used to simulate how a modal dialog blocks the document. The
@@ -187,6 +274,13 @@
 
     this.handleKey_ = this.handleKey_.bind(this);
     this.handleFocus_ = this.handleFocus_.bind(this);
+  };
+
+  /**
+   * @return {Element} the top HTML dialog element, if any
+   */
+  dialogPolyfill.DialogManager.prototype.topDialogElement = function() {
+    return this.pendingDialogStack[this.pendingDialogStack.length - 1].dialog;
   };
 
   /**
@@ -215,17 +309,15 @@
       if (i == this.pendingDialogStack.length - 1) {
         this.overlay.style.zIndex = zIndex++;
       }
-      var dialog = this.pendingDialogStack[i];
-      dialog.dialogPolyfillInfo.backdrop.style.zIndex = zIndex++;
-      dialog.style.zIndex = zIndex++;
+      var ds = this.pendingDialogStack[i];
+      ds.backdrop.style.zIndex = zIndex++;
+      ds.dialog.style.zIndex = zIndex++;
     }
   };
 
   dialogPolyfill.DialogManager.prototype.handleFocus_ = function(event) {
     var candidate = findNearestDialog(/** @type {Element} */ (event.target));
-    var dialog = this.pendingDialogStack[this.pendingDialogStack.length - 1];
-
-    if (candidate != dialog) {
+    if (candidate != this.topDialogElement()) {
       event.preventDefault();
       event.stopPropagation();
       event.target.blur();
@@ -243,34 +335,18 @@
         bubbles: false,
         cancelable: true
       });
-      var dialog = this.pendingDialogStack[this.pendingDialogStack.length - 1];
+      var dialog = this.topDialogElement();
       if (dialog.dispatchEvent(cancelEvent)) {
         dialog.close();
       }
     }
   };
 
-  dialogPolyfill.DialogManager.prototype.pushDialog = function(dialog) {
+  dialogPolyfill.DialogManager.prototype.pushDialog = function(dialog, backdrop) {
     if (this.pendingDialogStack.length >= MAX_PENDING_DIALOGS) {
       throw "Too many modal dialogs";
     }
-
-    var backdrop = document.createElement('div');
-    backdrop.className = 'backdrop';
-    var clickEventListener = function(e) {
-      var redirectedEvent = document.createEvent('MouseEvents');
-      redirectedEvent.initMouseEvent(e.type, e.bubbles, e.cancelable, window,
-          e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
-          e.altKey, e.shiftKey, e.metaKey, e.button, e.relatedTarget);
-      dialog.dispatchEvent(redirectedEvent);
-      e.stopPropagation();
-    };
-    backdrop.addEventListener('click', clickEventListener);
-    dialog.parentNode.insertBefore(backdrop, dialog.nextSibling);
-    dialog.dialogPolyfillInfo.backdrop = backdrop;
-    dialog.dialogPolyfillInfo.clickEventListener = clickEventListener;
-
-    this.pendingDialogStack.push(dialog);
+    this.pendingDialogStack.push({dialog: dialog, backdrop: backdrop});
     if (this.pendingDialogStack.length == 1) {
       this.blockDocument();
     }
@@ -278,19 +354,19 @@
   };
 
   dialogPolyfill.DialogManager.prototype.removeDialog = function(dialog) {
-    var index = this.pendingDialogStack.indexOf(dialog);
+    var index = -1;
+    for (var i = 0; i < this.pendingDialogStack.length; ++i) {
+      if (this.pendingDialogStack[i].dialog == dialog) {
+        index = i;
+        break;
+      }
+    }
     if (index == -1) {
       return;
     }
-    this.pendingDialogStack.splice(index, 1);
-    var backdrop = dialog.dialogPolyfillInfo.backdrop;
-    var clickEventListener = dialog.dialogPolyfillInfo.clickEventListener;
-    backdrop.removeEventListener('click', clickEventListener);
-    backdrop.parentNode.removeChild(backdrop);
-    dialog.dialogPolyfillInfo.backdrop = null;
-    dialog.dialogPolyfillInfo.clickEventListener = null;
-    this.updateStacking();
 
+    this.pendingDialogStack.splice(index, 1);
+    this.updateStacking();
     if (this.pendingDialogStack.length == 0) {
       this.unblockDocument();
     }

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -70,8 +70,6 @@
     this.backdrop_ = document.createElement('div');
     this.backdrop_.className = 'backdrop';
     this.backdropClick_ = this.backdropClick_.bind(this);
-
-    this.setOpen(dialog.hasAttribute('open'));
   }
 
   dialogPolyfillInfo.prototype = {

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -71,7 +71,7 @@
      */
     setOpen: function(value) {
       if (value && !this.open_) {
-        this.show();
+        this.show(this.modal_);
       } else if (!value && this.open_) {
         this.close();
       }
@@ -102,19 +102,20 @@
     /**
      * Shows the dialog.
      *
-     * @param {boolean=} opt_modal whether to display modal
+     * @param {boolean} modal whether to display modal
      */
-    show: function(opt_modal) {
+    show: function(modal) {
       if (this.open_) {
-        throw 'InvalidStateError: showDialog called on open dialog';
+        if (modal) {
+          throw 'Failed to execute \'showModal\' on dialog: The element is already open, and therefore cannot be opened modally.';
+        }
+        return;  // silently OK if we weren't asked to be shown modally
       }
       this.open_ = true;
+      this.modal_ = modal;
       this.dialog_.setAttribute('open', '');
-      if (opt_modal !== undefined) {
-        this.modal_ = opt_modal;
-      }
 
-      if (this.modal_) {
+      if (modal) {
         // Insert backdrop.
         this.backdrop_.addEventListener('click', this.backdropClick_);
         this.dialog_.parentNode.insertBefore(this.backdrop_,
@@ -140,7 +141,7 @@
       } else {
         this.replacedStyleTop_ = false;
       }
-      if (this.modal_) {
+      if (modal) {
         dialogPolyfill.dm.pushDialog(this.dialog_, this.backdrop_);
       }
     },

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -57,14 +57,9 @@
 
     if ('MutationObserver' in window) {
       var mo = new MutationObserver(function(mutations) {
-        var any = mutations.some(function(m) {
-          return 'open' == m.attributeName;
-        });
-        if (any) {
-          this.setOpen(dialog.getAttribute('open') !== null);
-        }
+        this.setOpen(dialog.hasAttribute('open'));
       }.bind(this));
-      mo.observe(dialog, { attributes: true });
+      mo.observe(dialog, { attributes: true, attributeFilter: ['open'] });
     }
 
     Object.defineProperty(dialog, 'open', {
@@ -138,9 +133,7 @@
 
       this.modal_ = modal;
       this.open_ = true;  // set open_ before attribute for observers
-      if (this.dialog_.getAttribute('open') === null) {
-        this.dialog_.setAttribute('open', '');  // allow user value of 'open'
-      }
+      this.dialog_.hasAttribute('open') || this.dialog_.setAttribute('open', '');
 
       if (modal) {
         // Insert backdrop.

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -249,8 +249,7 @@
       console.warn("This browser already supports <dialog>, the polyfill " +
           "may not work correctly.");
     }
-    var pfi = new dialogPolyfillInfo(element);
-    // TODO: ?
+    new dialogPolyfillInfo(element);
   };
 
   // The overlay is used to simulate how a modal dialog blocks the document. The

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -85,12 +85,13 @@
     maybeHideModal_: function() {
       if (!this.openAsModal_) { return; }
       this.openAsModal_ = false;
+      this.dialog_.style.zIndex = '';
 
       // This won't match the native <dialog> exactly because if the user set
       // top on a centered polyfill dialog, that top gets thrown away when the
       // dialog is closed. Not sure it's possible to polyfill this perfectly.
       if (this.replacedStyleTop_) {
-        this.dialog_.style.top = 'auto';
+        this.dialog_.style.top = '';
         this.replacedStyleTop_ = false;
       }
 

--- a/suite.js
+++ b/suite.js
@@ -88,21 +88,38 @@ void function() {
     dialog = createDialog('Default Dialog');
   });
 
-  test('basic', function() {
-    assert.isFalse(dialog.hasAttribute('open'));
-    dialog.show();
-    assert.isTrue(dialog.hasAttribute('open'));
-    assert.isTrue(dialog.open);
+  suite('basic', function() {
+    test('show and close', function() {
+      assert.isFalse(dialog.hasAttribute('open'));
+      dialog.show();
+      assert.isTrue(dialog.hasAttribute('open'));
+      assert.isTrue(dialog.open);
 
-    var returnValue = 1234;
-    dialog.close(returnValue);
-    assert.isFalse(dialog.hasAttribute('open'));
-    assert.equal(dialog.returnValue, returnValue);
+      var returnValue = 1234;
+      dialog.close(returnValue);
+      assert.isFalse(dialog.hasAttribute('open'));
+      assert.equal(dialog.returnValue, returnValue);
 
-    dialog.show();
-    dialog.close();
-    assert.isFalse(dialog.open);
-    assert.equal(dialog.returnValue, returnValue);
+      dialog.show();
+      dialog.close();
+      assert.isFalse(dialog.open);
+      assert.equal(dialog.returnValue, returnValue);
+    });
+    test('open property', function() {
+      assert.isFalse(dialog.hasAttribute('open'));
+      dialog.show();
+      assert.isTrue(dialog.hasAttribute('open'));
+      assert.isTrue(dialog.open);
+
+      dialog.open = false;
+      assert.isFalse(dialog.open);
+      assert.isFalse(dialog.hasAttribute('open'),
+          'open property should clear attribute');
+      assert.throws(dialog.close);
+
+      var overlay = document.querySelector('._dialog_overlay');
+      assert.isNull(overlay);
+    });
   });
 
   suite('position', function() {

--- a/suite.js
+++ b/suite.js
@@ -135,6 +135,20 @@ void function() {
 
       assert.isTrue(dialog.open);
     });
+    test('setAttribute reflects property', function() {
+      dialog.setAttribute('open', '');
+      assert.isTrue(dialog.open, 'attribute opens dialog');
+    });
+    test('show/showModal outside document', function() {
+      dialog.open = false;
+      dialog.parentNode.removeChild(dialog);
+
+      assert.throws(dialog.showModal);
+
+      assert.doesNotThrow(dialog.show);
+      assert.isTrue(dialog.open, 'can open non-modal outside document');
+      assert.isFalse(document.body.contains(dialog));
+    });
   });
 
   suite('position', function() {

--- a/suite.js
+++ b/suite.js
@@ -120,6 +120,21 @@ void function() {
       var overlay = document.querySelector('._dialog_overlay');
       assert.isNull(overlay);
     });
+    test('show/showModal interaction', function() {
+      assert.isFalse(dialog.hasAttribute('open'));
+      dialog.show();
+
+      assert.doesNotThrow(dialog.show);
+      assert.throws(dialog.showModal);
+
+      dialog.open = false;
+      assert.doesNotThrow(dialog.showModal);
+      assert.doesNotThrow(dialog.show);  // show after showModal does nothing
+      assert.throws(dialog.showModal);
+      // TODO: check dialog is still modal
+
+      assert.isTrue(dialog.open);
+    });
   });
 
   suite('position', function() {

--- a/suite.js
+++ b/suite.js
@@ -165,6 +165,9 @@ void function() {
     test('default modal centering', function() {
       dialog.showModal();
       checkDialogCenter();
+      assert.ok(dialog.style.top, 'expected top to be set');
+      dialog.close();
+      assert.notOk(dialog.style.top, 'expected top to be cleared');
     });
     test('modal respects static position', function() {
       dialog.style.top = '10px';
@@ -426,6 +429,9 @@ void function() {
 
       assert.equal(window.getComputedStyle(one).zIndex, 100);
       assert.equal(window.getComputedStyle(two).zIndex, 200);
+
+      two.close();
+      assert.equal(window.getComputedStyle(two).zIndex, 200);
     });
     test('modal stacking order', function() {
       dialog.showModal();
@@ -456,6 +462,9 @@ void function() {
       assert.isBelow(zfb, zf,' backdrop below dialog');
 
       assert.isAbove(zfb, zb, 'front backdrop is above back dialog');
+
+      front.close();
+      assert.notOk(front.style.zIndex, 'modal close should clear zindex');
     });
   });
 


### PR DESCRIPTION
This is a pretty big refactor. It basically more neatly creates a parallel `dialogPolyfillInfo` class alongside each upgraded `dialog`.

Some benefits-

- the `open` property is now just a proxy for the `open` attribute, and some associated benefits
- clearer modal dialog removal, and future-proofing for observers

@wibblymat 