### PR TITLE
Fixed centered-alignment if dialog is taller than the viewport.

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -227,7 +227,7 @@
   dialogPolyfill.reposition = function(element) {
     var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
     var topValue = scrollTop + (window.innerHeight - element.offsetHeight) / 2;
-    element.style.top = Math.max(0, topValue) + 'px';
+    element.style.top = Math.max(scrollTop, topValue) + 'px';
   };
 
   dialogPolyfill.isInlinePositionSetByStylesheet = function(element) {


### PR DESCRIPTION
The spec dictates that if the dialog is displayed in centered-alignment and the dialog is taller than the viewport, then the dialog shall be placed at the top of the viewport.  Instead, the polyfill was always centering the dialog even if it was taller than the viewport.

https://html.spec.whatwg.org/multipage/forms.html#centered-alignment