### PR TITLE
The activeElement doesn't seem to have blur in IE 11.0.9600.18015

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -198,7 +198,7 @@
         }).join(', ');
         target = this.dialog_.querySelector(query);
       }
-      document.activeElement && document.activeElement.blur();
+      document.activeElement && document.activeElement.blur && document.activeElement.blur();
       target && target.focus();
     },
 


### PR DESCRIPTION
This second last line of the showModal function failed in my application as the activeElement doesn't seem to have a blur function. The last line of the function would have set the focus. This line wasn't executed anymore.