### PR TITLE
Update dialog-polyfill.js to support open event

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -153,14 +153,21 @@
     },
 
     /**
-     * Shows the dialog. This is idempotent and will always succeed.
+     * Shows the dialog. This is idempotent and will always succeed. Also triggers an open event.
      */
     show: function() {
       this.setOpen(true);
+      
+       // Triggering "open" event for any attached listeners on the <dialog>.
+      var openEvent = new supportCustomEvent('open', {
+        bubbles: false,
+        cancelable: false
+      });
+      this.dialog_.dispatchEvent(openEvent);
     },
 
     /**
-     * Show this dialog modally.
+     * Show this dialog modally. Also triggers an open event.
      */
     showModal: function() {
       if (this.dialog_.hasAttribute('open')) {
@@ -200,6 +207,13 @@
       }
       document.activeElement && document.activeElement.blur && document.activeElement.blur();
       target && target.focus();
+      
+      // Triggering "open" event for any attached listeners on the <dialog>.
+      var openEvent = new supportCustomEvent('open', {
+        bubbles: false,
+        cancelable: false
+      });
+      this.dialog_.dispatchEvent(openEvent);
     },
 
     /**


### PR DESCRIPTION
When the a dialog's `open` or `showModal` event is invoked, trigger an open event to correspond with the close event to comply w/ WHATWG expectations on how the dialog element should work. To not break the Principle of Least Surprise of the existing behavior of the Polyfill, the open event is only fired when `show` & `showModal` methods are explicitly used like how the `close` method currently behaves & differs from using the open attribute explicitly.

## Overall Side-effects
- [x] Open event fires when `show` & `showModal` methods are used. 