### PR TITLE
Ensure a proper role attribute is set to polyfilled dialog instances 

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -60,18 +60,16 @@
 
     this.maybeHideModal = this.maybeHideModal.bind(this);
     this.maybeSetADefaultRoleValue = this.maybeSetADefaultRoleValue.bind(this);
+    this.callMaybies = this.callMaybies.bind(this);
 
     if ('MutationObserver' in window) {
       // IE11+, most other browsers.
-      var mo = new MutationObserver(this.maybeHideModal);
-      mo.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+      var mo = new MutationObserver(this.callMaybies);
+      mo.observe(dialog, { attributes: true, attributeFilter: ['open', 'role'] });
 
-      var mo2 = new MutationObserver(this.maybeSetADefaultRoleValue);
-      mo2.observe(dialog, { attributes: true, attributeFilter: ['role'] });
 
     } else {
-      dialog.addEventListener('DOMAttrModified', this.maybeHideModal);
-      dialog.addEventListener('DOMAttrModified', this.maybeSetDefaultRoleValue);
+      dialog.addEventListener('DOMAttrModified', this.callMaybies);
     }
     // Note that the DOM is observed inside DialogManager while any dialog
     // is being displayed as a modal, to catch modal removal from the DOM.
@@ -128,9 +126,18 @@
      * for its core usage in a Web application.
      */
     maybeSetADefaultRoleValue: function(){
-      if ( !this.dialog.hasAttribute('role') || this.dialog.getAttribute('role') == ''  ) {
+      if ( !this.dialog.hasAttribute('role') || this.dialog.getAttribute('role') === ''  ) {
         this.dialog.setAttribute( 'role', 'dialog'  );
       }
+    },
+
+    /**
+    * Handles the simultaneous need to call series of Maybies for the dialog
+    * commonly needed to be considered in quick succession to one another.
+    */
+    callMaybies: function(){
+      this.maybeHideModal();
+      this.maybeSetADefaultRoleValue();
     },
 
     /**

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -59,12 +59,19 @@
     }
 
     this.maybeHideModal = this.maybeHideModal.bind(this);
+    this.maybeSetADefaultRoleValue = this.maybeSetADefaultRoleValue.bind(this);
+
     if ('MutationObserver' in window) {
       // IE11+, most other browsers.
       var mo = new MutationObserver(this.maybeHideModal);
       mo.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+
+      var mo2 = new MutationObserver(this.maybeSetADefaultRoleValue);
+      mo2.observe(dialog, { attributes: true, attributeFilter: ['role'] });
+
     } else {
       dialog.addEventListener('DOMAttrModified', this.maybeHideModal);
+      dialog.addEventListener('DOMAttrModified', this.maybeSetDefaultRoleValue);
     }
     // Note that the DOM is observed inside DialogManager while any dialog
     // is being displayed as a modal, to catch modal removal from the DOM.
@@ -77,6 +84,7 @@
     this.backdrop_ = document.createElement('div');
     this.backdrop_.className = 'backdrop';
     this.backdropClick_ = this.backdropClick_.bind(this);
+    this.maybeSetADefaultRoleValue();
   }
 
   dialogPolyfillInfo.prototype = {
@@ -112,6 +120,17 @@
         this.backdrop_.parentElement.removeChild(this.backdrop_);
       }
       dialogPolyfill.dm.removeDialog(this);
+    },
+
+    /**
+     * Maybe assign a default role attribute to this dialog that is being
+     * polyfilled. Without one, the dialog won't have a useful a11y tree generated
+     * for its core usage in a Web application.
+     */
+    maybeSetADefaultRoleValue: function(){
+      if ( !this.dialog.hasAttribute('role') || this.dialog.getAttribute('role') == ''  ) {
+        this.dialog.setAttribute( 'role', 'dialog'  );
+      }
     },
 
     /**


### PR DESCRIPTION
## Goals of this PR
- [x] Ensure that a proper role attribute is consistently set for the the polyfilled dialog element when initially polyfilled w/ conditions respectable to a more nuanced role attribute be set by users of the polyfilld
- [x] Ensure that a relevant role dialog attribute is continuously set 
- [x] Closes Issue #63 

## Side Effects
- A new function `maybeSetADefaultRoleValue` is defined that has the core logic associated with the goals of this PR
- A new function `callMaybies` has also been defined. This enables the new functionality encapsulated by `maybeSetADefaultRoleValue` to be fired alongside `maybeHideModal`; the `MutationObserver` instance `mo` with its  observer settings has been changed to do so. Otherwise, two listeners and mutation observers would be within the body of `dialogPolyfillInfo` which is seemingly not ideal. (See commit cfb7774 to see this).
- The observer settings of `MutationObserver` instance `mo` has been changed. To be specific, the `role` attribute alongside the `open` attribute is now being watched.  
- The fallback `MutationEvent` event listener associated with the `DOMAttrModified` event if `MutationObserver` isn't available to some browsers  has been changed to invoke `callMaybies` instead of `maybeCloseModal`.

## Considerations for reviewers to make
- Is Maybies even a word? :sweat_smile: 
- Is it a premature micro-optimization to consolidate things to avoid two fallback listeners and two MutationObservers. Knowing that `MutationEvent` is notoriously expensive (and why `MutationObserver` now exists to secede it), that alone was an improvement of the MVP of this functionality. Don't know about the rest even after profiling.

The last section seems to be  most appropriate for @samthor to review 