### PR TITLE
Don’t expose polyfill to global when in CJS/AMD

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -493,6 +493,9 @@
     dialog.close(returnValue);
   }, true);
 
+  dialogPolyfill['forceRegisterDialog'] = dialogPolyfill.forceRegisterDialog;
+  dialogPolyfill['registerDialog'] = dialogPolyfill.registerDialog;
+
   if (typeof module === 'object' && typeof module['exports'] === 'object') {
     // CommonJS support
     module['exports'] = dialogPolyfill;
@@ -500,6 +503,7 @@
     // AMD support
     define(function() { return dialogPolyfill; });
   } else {
+    // all others
     window['dialogPolyfill'] = dialogPolyfill;
   }
 })();

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -493,15 +493,13 @@
     dialog.close(returnValue);
   }, true);
 
-  window['dialogPolyfill'] = dialogPolyfill;
-  dialogPolyfill['forceRegisterDialog'] = dialogPolyfill.forceRegisterDialog;
-  dialogPolyfill['registerDialog'] = dialogPolyfill.registerDialog;
-
   if (typeof module === 'object' && typeof module['exports'] === 'object') {
     // CommonJS support
     module['exports'] = dialogPolyfill;
   } else if (typeof define === 'function' && 'amd' in define) {
     // AMD support
     define(function() { return dialogPolyfill; });
+  } else {
+    window['dialogPolyfill'] = dialogPolyfill;
   }
 })();


### PR DESCRIPTION
Closes #93.

Also, I’ve removed `forceRegisterDialog` and `registerDialog` methods since they’re already defined on `dialogPolyfill` object which is exported to `window`. I suppose that’s OK?