### PR TITLE
add role dialog to upgraded dialogs

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -63,6 +63,11 @@
     this.replacedStyleTop_ = false;
     this.openAsModal_ = false;
 
+    // Set a11y role. Browsers that support dialog implicitly know this already.
+    if (!dialog.hasAttribute('role')) {
+      dialog.setAttribute('role', 'dialog');
+    }
+
     dialog.show = this.show.bind(this);
     dialog.showModal = this.showModal.bind(this);
     dialog.close = this.close.bind(this);

--- a/suite.js
+++ b/suite.js
@@ -181,6 +181,9 @@ void function() {
         done();
       }, 0);
     });
+    test('has a11y property', function() {
+      assert.equal(dialog.getAttribute('role'), 'dialog', 'role should be dialog');
+    });
   });
 
   suite('position', function() {


### PR DESCRIPTION
This is a quick fix for now, but with a couple of caveats-

* `aria-hidden` is not set (see [spec](https://www.w3.org/TR/wai-aria/complete#aria-hidden)), and it's not clear that a dialog being implicitly hidden via CSS is helpful
* arguably, a modal dialog should be an [alertdialog](https://www.w3.org/TR/wai-aria/complete#alertdialog) (but, dialogs can be shown in either way, so this would change)