### PR TITLE
Prioritise AMD module definition

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -513,12 +513,12 @@
   dialogPolyfill['forceRegisterDialog'] = dialogPolyfill.forceRegisterDialog;
   dialogPolyfill['registerDialog'] = dialogPolyfill.registerDialog;
 
-  if (typeof module === 'object' && typeof module['exports'] === 'object') {
-    // CommonJS support
-    module['exports'] = dialogPolyfill;
-  } else if (typeof define === 'function' && 'amd' in define) {
+  if (typeof define === 'function' && 'amd' in define) {
     // AMD support
     define(function() { return dialogPolyfill; });
+  } else if (typeof module === 'object' && typeof module['exports'] === 'object') {
+    // CommonJS support
+    module['exports'] = dialogPolyfill;
   } else {
     // all others
     window['dialogPolyfill'] = dialogPolyfill;


### PR DESCRIPTION
In environments like electron, `module['exports']` could also be available, when the website code is using AMD. Previous module definition code was preventing dialog polyfill from being defined as an AMD module in electron since it was cheking CJS module availability first, this PR prioritises AMD definition.