### PR TITLE
Remove warning that browser already supports <dialog>

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -326,12 +326,10 @@
   };
 
   /**
-   * @param {!Element} element to upgrade
+   * @param {!Element} element to upgrade, if necessary
    */
   dialogPolyfill.registerDialog = function(element) {
-    if (element.showModal) {
-      console.warn('Can\'t upgrade <dialog>: already supported', element);
-    } else {
+    if (!element.showModal) {
       dialogPolyfill.forceRegisterDialog(element);
     }
   };


### PR DESCRIPTION
Polyfills probably don't need to warn users that their browser already supports the feature they're polyfilling.

i.e. https://youtu.be/VTp5MTlq4GU?t=70