### PR TITLE
Remove anchoring reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ When using the polyfill, the backdrop will be an adjacent element:
   - Stacking can be ruined by playing with z-index
   - Changes to the CSS top/bottom values while open aren't retained
 
-- Anchored positioning is not implemented, but the native `<dialog>` in Chrome doesn't have it either
-
 ### Position
 
 One major limitation of the polyfill is that dialogs must have parents without layout.


### PR DESCRIPTION
Removed from spec: https://github.com/whatwg/html/pull/2158

No need to keep this in the readme since it won't ever be supported nor is spec-wise needed anymore.
