### PR TITLE
Move the script tag to the body in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This polyfill works on modern versions of all major browsers. It also supports I
 
 ### Steps
 
-1. Include the JavaScript, followed by the CSS in the `<head>` of your document.
+1. Include the CSS in the `<head>` of your document, and the Javascript anywhere before referencing `dialogPolyfill`.
 2. Create your dialog elements within the document. See [limitations](#limitations) for more details.
 3. Register the elements using `dialogPolyfill.registerDialog()`, passing it one node at a time. This polyfill won't replace native support.
 4. Use your `<dialog>` elements!
@@ -29,7 +29,6 @@ This polyfill works on modern versions of all major browsers. It also supports I
 
 ```html
 <head>
-  <script src="dialog-polyfill.js"></script>
   <link rel="stylesheet" type="text/css" href="dialog-polyfill.css" />
 </head>
 <body>
@@ -39,6 +38,7 @@ This polyfill works on modern versions of all major browsers. It also supports I
       <input type="submit" value="Close" />
     </form>
   </dialog>
+  <script src="dialog-polyfill.js"></script>
   <script>
     var dialog = document.querySelector('dialog');
     dialogPolyfill.registerDialog(dialog);


### PR DESCRIPTION
This means that the script won't block rendering earlier than needed. A preferable solution would be to use the `async` HTML attribute, but that would require a way to put the custom code in a callback, and this library isn't ready for that yet.

If you don't want to change the example code, than at least document that the script tag's location is not required to be in the <head> section. As it stands, developers that are using the polyfill do not know the best place to put it by default as you said, because it doesn't just depend on the site infrastructure, it also depends on the behaviour of the script. For example, if a script is calling document.write, it will behave differently depending on whether it's in the <head> section or not. Even if I fully review the script's code and determine that it behaves correctly when included in the <body> section now, I don't have the reassurances of the documentation that an upgrade won't break it.