### PR TITLE
flip to MutationObserver for more things

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -1,5 +1,6 @@
 (function() {
 
+  // nb. This is for IE10 and lower _only_.
   var supportCustomEvent = window.CustomEvent;
   if (!supportCustomEvent || typeof supportCustomEvent == 'object') {
     supportCustomEvent = function CustomEvent(event, x) {
@@ -19,7 +20,7 @@
    */
   function findNearestDialog(el) {
     while (el) {
-      if (el.nodeName.toUpperCase() == 'DIALOG') {
+      if (el.localName === 'dialog') {
         return /** @type {HTMLDialogElement} */ (el);
       }
       el = el.parentElement;
@@ -76,13 +77,20 @@
       dialog.returnValue = '';
     }
 
-    this.maybeHideModal = this.maybeHideModal.bind(this);
+    var cb = this.maybeHideModal.bind(this);
     if ('MutationObserver' in window) {
-      // IE11+, most other browsers.
-      var mo = new MutationObserver(this.maybeHideModal);
-      mo.observe(dialog, { attributes: true, attributeFilter: ['open'] });
+      var mo = new MutationObserver(cb);
+      mo.observe(dialog, {attributes: true, attributeFilter: ['open']});
     } else {
-      dialog.addEventListener('DOMAttrModified', this.maybeHideModal);
+      // IE10 and below support. Note that DOMNodeRemoved etc fire _before_ removal.
+      var timeout;
+      var delayModel = function() {
+        window.clearTimeout(timeout);
+        timeout = window.setTimeout(cb, 0);
+      };
+      ['DOMAttrModified', 'DOMNodeRemoved', 'DOMNodeRemovedFromDocument'].forEach(function(name) {
+        dialog.addEventListener(name, delayModel);
+      }, this);
     }
     // Note that the DOM is observed inside DialogManager while any dialog
     // is being displayed as a modal, to catch modal removal from the DOM.
@@ -110,9 +118,7 @@
      */
     maybeHideModal: function() {
       if (!this.openAsModal_) { return; }
-      if (this.dialog_.hasAttribute('open') &&
-          document.body.contains(this.dialog_)) { return; }
-
+      if (this.dialog_.hasAttribute('open') && document.body.contains(this.dialog_)) { return; }
       this.openAsModal_ = false;
       this.dialog_.style.zIndex = '';
 
@@ -339,7 +345,7 @@
       console.warn('This browser already supports <dialog>, the polyfill ' +
           'may not work correctly', element);
     }
-    if (element.nodeName.toUpperCase() != 'DIALOG') {
+    if (element.localName !== 'dialog') {
       throw new Error('Failed to register dialog: The element is not a dialog.');
     }
     new dialogPolyfillInfo(/** @type {!HTMLDialogElement} */ (element));
@@ -375,12 +381,25 @@
 
     this.handleKey_ = this.handleKey_.bind(this);
     this.handleFocus_ = this.handleFocus_.bind(this);
-    this.handleRemove_ = this.handleRemove_.bind(this);
 
     this.zIndexLow_ = 100000;
     this.zIndexHigh_ = 100000 + 150;
 
     this.forwardTab_ = undefined;
+
+    if ('MutationObserver' in window) {
+      this.mo_ = new MutationObserver(function(records) {
+        var valid = records.some(function(rec) {
+          for (var i = 0, c; c = rec.removedNodes[i]; ++i) {
+            if (c.localName === 'dialog') {
+              return true;
+            }
+          }
+          return false;
+        });
+        valid && this.checkDOM_();
+      }.bind(this));
+    }
   };
 
   /**
@@ -391,7 +410,7 @@
     document.body.appendChild(this.overlay);
     document.documentElement.addEventListener('focus', this.handleFocus_, true);
     document.addEventListener('keydown', this.handleKey_);
-    document.addEventListener('DOMNodeRemoved', this.handleRemove_);
+    this.mo_ && this.mo_.observe(document, {childList: true, subtree: true});
   };
 
   /**
@@ -402,7 +421,7 @@
     document.body.removeChild(this.overlay);
     document.documentElement.removeEventListener('focus', this.handleFocus_, true);
     document.removeEventListener('keydown', this.handleKey_);
-    document.removeEventListener('DOMNodeRemoved', this.handleRemove_);
+    this.mo_ && this.mo_.disconnect();
   };
 
   dialogPolyfill.DialogManager.prototype.updateStacking = function() {
@@ -467,11 +486,6 @@
     });
   };
 
-  dialogPolyfill.DialogManager.prototype.handleRemove_ = function(event) {
-    if (event.target.nodeName.toUpperCase() !== 'DIALOG') { return; }
-    this.checkDOM_();
-  };
-
   /**
    * @param {!dialogPolyfillInfo} dpi
    * @return {boolean} whether the dialog was allowed
@@ -511,7 +525,7 @@
   document.addEventListener('submit', function(ev) {
     var target = ev.target;
     if (!target || !target.hasAttribute('method')) { return; }
-    if (target.getAttribute('method').toLowerCase() != 'dialog') { return; }
+    if (target.getAttribute('method').toLowerCase() !== 'dialog') { return; }
     ev.preventDefault();
 
     var dialog = findNearestDialog(/** @type {Element} */ (ev.target));

--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -82,7 +82,8 @@
       var mo = new MutationObserver(cb);
       mo.observe(dialog, {attributes: true, attributeFilter: ['open']});
     } else {
-      // IE10 and below support. Note that DOMNodeRemoved etc fire _before_ removal.
+      // IE10 and below support. Note that DOMNodeRemoved etc fire _before_ removal. They also
+      // seem to fire even if the element was removed as part of a parent removal.
       var timeout;
       var delayModel = function() {
         window.clearTimeout(timeout);
@@ -391,7 +392,8 @@
       this.mo_ = new MutationObserver(function(records) {
         var valid = records.some(function(rec) {
           for (var i = 0, c; c = rec.removedNodes[i]; ++i) {
-            if (c.localName === 'dialog') {
+            // is this removal a dialog, or contain a dialog?
+            if (c instanceof Element && (c.localName === 'dialog' || c.querySelector('dialog'))) {
               return true;
             }
           }

--- a/suite.js
+++ b/suite.js
@@ -167,15 +167,15 @@ void function() {
       var parentNode = dialog.parentNode;
       parentNode.removeChild(dialog);
 
-      // DOMNodeRemoved happens at the end of the frame: this test must be
-      // async to complete successfully.
+      // DOMNodeRemoved defers its task a frame (since it occurs before removal, not after). This
+      // doesn't effect MutationObserver, just delays the test a frame.
       window.setTimeout(function() {
         assert.isNull(document.querySelector('.backdrop'), 'dialog removal should clear modal');
 
         assert.isTrue(dialog.open, 'removed dialog should still be open');
         parentNode.appendChild(dialog);
 
-        assert.isTrue(dialog.open, 'removed dialog should still be open');
+        assert.isTrue(dialog.open, 're-added dialog should still be open');
         assert.isNull(document.querySelector('.backdrop'), 're-add dialog should not be modal');
 
         done();

--- a/suite.js
+++ b/suite.js
@@ -181,6 +181,20 @@ void function() {
         done();
       }, 0);
     });
+    test('DOM removal inside other element', function(done) {
+      var div = cleanup(document.createElement('div'));
+      document.body.appendChild(div);
+      div.appendChild(dialog);
+
+      dialog.showModal();
+      document.body.removeChild(div);
+
+      window.setTimeout(function() {
+        assert.isNull(document.querySelector('.backdrop'), 'dialog removal should clear modal');
+        assert.isTrue(dialog.open, 'removed dialog should still be open');
+        done();
+      }, 0);
+    });
     test('has a11y property', function() {
       assert.equal(dialog.getAttribute('role'), 'dialog', 'role should be dialog');
     });


### PR DESCRIPTION
Fixes #103 and #72.

This may actually fix other issues; `DOMNodeRemoved` wasn't firing as expected. Now the event is set on the element itself, and it's only relevant where we don't have `MutationObserver` anyway.