### PR TITLE
fixed undefined variable usage

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -521,7 +521,8 @@
     event.stopPropagation();
     safeBlur(/** @type {Element} */ (event.target));
 
-    var dialog = this.pendingDialogStack[0].dialog;
+    var dpi = this.pendingDialogStack[0]
+    var dialog = dpi.dialog;
     var position = dialog.compareDocumentPosition(event.target);
     if (position & Node.DOCUMENT_POSITION_PRECEDING) {
       if (this.forwardTab_) {

--- a/suite.js
+++ b/suite.js
@@ -683,4 +683,18 @@ void function() {
     });
   });
 
+  suite('press tab key', function() {
+    test('tab key', function() {
+      var dialog = createDialog();
+      dialog.showModal();
+
+      document.documentElement.dispatchEvent(createKeyboardEvent(9))
+
+      var ev = document.createEvent('Events');
+      ev.initEvent('focus', true, true);
+      document.documentElement.dispatchEvent(ev);
+
+      dialog.close();
+    });
+  });
 }();


### PR DESCRIPTION
When pressing the tab key in firefox caused an undefined reference error to be hit. Looks like maybe it was a regression introduced by commit 76112e8c75fee6b8312dff78105e31d0ba1c112b

I wasn't sure how to write a test to validate that the behavior is actually correct, so I just wrote one that caused the error. 