### PR TITLE
replaces HTMLFormElement.prototype.submit as it doesn't call submit

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -641,6 +641,20 @@
   });
 
   /**
+   * Replace the native HTMLFormElement.submit() method, as it won't fire the
+   * submit event and give us a chance to respond.
+   */
+  var nativeFormSubmit = HTMLFormElement.prototype.submit;
+  function replacementFormSubmit() {
+    if (!isFormMethodDialog(this)) {
+      return nativeFormSubmit.apply(this);
+    }
+    var dialog = findNearestDialog(this);
+    dialog && dialog.close();
+  }
+  HTMLFormElement.prototype.submit = replacementFormSubmit;
+
+  /**
    * Global form 'dialog' method handler. Closes a dialog correctly on submit
    * and possibly sets its return value.
    */

--- a/suite.js
+++ b/suite.js
@@ -604,18 +604,12 @@ void function() {
     test('dialog programmatic submit does not change returnValue', function() {
       var form = document.createElement('form');
       form.setAttribute('method', 'dialog');
+
+      dialog.returnValue = 'manually set';  // set before appending
       dialog.appendChild(form);
 
-      var button = document.createElement('button');
-      button.value = 'should not be this value';
-      form.appendChild(button);
-
-      dialog.returnValue = 'manually set';
-
       dialog.showModal();
-      button.click();
-      // FIXME: form.submit broken (see https://github.com/GoogleChrome/dialog-polyfill/issues/142)
-      // form.submit();
+      form.submit();
       assert.isFalse(dialog.open);
 
       assert.equal(dialog.returnValue, 'manually set', 'returnValue should not change');


### PR DESCRIPTION
Resolves #142.