### PR TITLE
Fix DOMNodeRemoved bubble (Issue #150)

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -128,6 +128,7 @@
       }.bind(this);
       var timeout;
       var delayModel = function(ev) {
+        if (ev.target !== dialog) return; // Not for a child element
         var cand = 'DOMNodeRemoved';
         removed |= (ev.type.substr(0, cand.length) === cand);
         window.clearTimeout(timeout);


### PR DESCRIPTION
The `DOMNodeRemoved` event bubbles, which incorrectly causes `downgradeModal()` in IE9/10 when the content changes.