### PR TITLE
Refactor from a function to a function expression to avoid block scoping

### DIFF
--- a/dialog-polyfill.js
+++ b/dialog-polyfill.js
@@ -689,13 +689,13 @@
      * submit event and give us a chance to respond.
      */
     var nativeFormSubmit = HTMLFormElement.prototype.submit;
-    function replacementFormSubmit() {
+    var replacementFormSubmit = function () {
       if (!isFormMethodDialog(this)) {
         return nativeFormSubmit.call(this);
       }
       var dialog = findNearestDialog(this);
       dialog && dialog.close();
-    }
+    };
     HTMLFormElement.prototype.submit = replacementFormSubmit;
 
     /**


### PR DESCRIPTION
Avoid using a block scoped function. Closure-compiler now errors in this case if the language_out flag is less than ECMASCRIPT6.

FYI I'm not sure how to run the tests.