### PR TITLE
Use long-term stable URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are several ways that to include the dialog polyfill:
 
 ```javascript
 // direct import (script module, deno)
-import dialogPolyfill from './node_modules/dialog-polyfill/index.js';
+import dialogPolyfill from './node_modules/dialog-polyfill/dist/dialog-polyfill.esm.js';
 
 // *OR*
 


### PR DESCRIPTION
While the files are the same now, better to point to `dist` ESM instead of source in case source files are split up or require dependencies.