### PR TITLE
Support finding focusable items in custom element shadow roots

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,11 @@ function findNearestDialog(el) {
  * @param {Element} el to blur
  */
 function safeBlur(el) {
+  // Find the actual focused element when the active element is inside a shadow root
+  while(el && el.shadowRoot && el.shadowRoot.activeElement) {
+    el = el.shadowRoot.activeElement;
+  }
+
   if (el && el.blur && el !== document.body) {
     el.blur();
   }
@@ -108,12 +113,12 @@ function findFocusableElementInShadowDom(hostElement) {
   target = hostElement.querySelector(query.join(', '));
 
   if (!target) {
-    // If we haven't found a focusable target, see if the host element contains any custom elements.
-    // While any element can technically have a shadowRoot, custom elements are likely to.
+    // If we haven't found a focusable target, see if the host element contains an element
+    // which has a shadowRoot.
     // Recursively search for the first focusable item in shadow roots.
     var elems = hostElement.querySelectorAll('*');
     for (var i = 0; i < elems.length; i++) {
-      if (elems[i].tagName && elems[i].tagName.indexOf('-') > 0 && elems[i].shadowRoot) {
+      if (elems[i].tagName && elems[i].shadowRoot) {
         target = findFocusableElementInShadowDom(elems[i].shadowRoot);
         if (target) {
           break;

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function findNearestDialog(el) {
  */
 function safeBlur(el) {
   // Find the actual focused element when the active element is inside a shadow root
-  while(el && el.shadowRoot && el.shadowRoot.activeElement) {
+  while (el && el.shadowRoot && el.shadowRoot.activeElement) {
     el = el.shadowRoot.activeElement;
   }
 
@@ -101,7 +101,7 @@ function isFormMethodDialog(el) {
  * @param {!DocumentFragment|!Element} hostElement
  * @return {?Element} 
  */
-function findFocusableElementInShadowDom(hostElement) {
+function findFocusableElementWithin(hostElement) {
   // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
   // alternative involves stepping through and trying to focus everything.
   var opts = ['button', 'input', 'keygen', 'select', 'textarea'];
@@ -112,14 +112,14 @@ function findFocusableElementInShadowDom(hostElement) {
   query.push('[tabindex]:not([disabled]):not([tabindex=""])');  // tabindex != "", not disabled
   var target = hostElement.querySelector(query.join(', '));
 
-  if (!target) {
+  if (!target && 'attachShadow' in Element.prototype) {
     // If we haven't found a focusable target, see if the host element contains an element
     // which has a shadowRoot.
     // Recursively search for the first focusable item in shadow roots.
     var elems = hostElement.querySelectorAll('*');
     for (var i = 0; i < elems.length; i++) {
       if (elems[i].tagName && elems[i].shadowRoot) {
-        target = findFocusableElementInShadowDom(elems[i].shadowRoot);
+        target = findFocusableElementWithin(elems[i].shadowRoot);
         if (target) {
           break;
         }
@@ -276,7 +276,7 @@ dialogPolyfillInfo.prototype = /** @type {HTMLDialogElement.prototype} */ ({
       target = this.dialog_;
     }
     if (!target) {
-      target = findFocusableElementInShadowDom(this.dialog_);
+      target = findFocusableElementWithin(this.dialog_);
     }
     safeBlur(document.activeElement);
     target && target.focus();

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function findFocusableElementInShadowDom(hostElement) {
   });
   // TODO(samthor): tabindex values that are not numeric are not focusable.
   query.push('[tabindex]:not([disabled]):not([tabindex=""])');  // tabindex != "", not disabled
-  target = hostElement.querySelector(query.join(', '));
+  var target = hostElement.querySelector(query.join(', '));
 
   if (!target) {
     // If we haven't found a focusable target, see if the host element contains an element
@@ -188,7 +188,7 @@ function dialogPolyfillInfo(dialog) {
   this.backdrop_.addEventListener('click', this.backdropClick_.bind(this));
 }
 
-dialogPolyfillInfo.prototype = {
+dialogPolyfillInfo.prototype = /** @type {HTMLDialogElement.prototype} */ ({
 
   get dialog() {
     return this.dialog_;
@@ -369,7 +369,7 @@ dialogPolyfillInfo.prototype = {
     this.dialog_.dispatchEvent(closeEvent);
   }
 
-};
+});
 
 var dialogPolyfill = {};
 
@@ -681,6 +681,7 @@ if (window.HTMLDialogElement === undefined) {
         return realGet.call(this);
       };
       var realSet = methodDescriptor.set;
+      /** @this {HTMLElement} */
       methodDescriptor.set = function(v) {
         if (typeof v === 'string' && v.toLowerCase() === 'dialog') {
           return this.setAttribute('method', v);


### PR DESCRIPTION
When searching for a focusable item, we need to consider that the dialog may contain custom elements which have shadow roots. If we fail to find a focusable target by conventional means, look for custom elements (must have a '-' in the tag name) and search their shadow roots recursively.

<img width="747" alt="Screen Shot 2019-04-05 at 7 16 56 AM" src="https://user-images.githubusercontent.com/1247639/55627243-4b700980-5773-11e9-8c1d-44cf8f0c94de.png">
