### PR TITLE
Support for explicit `onclose` handler

### DIFF
--- a/dist/dialog-polyfill.js
+++ b/dist/dialog-polyfill.js
@@ -342,7 +342,15 @@
         bubbles: false,
         cancelable: false
       });
+    
+      // If we have an onclose handler assigned and it's a function, call it
+      if(this.dialog_.onclose instanceof Function) {
+        this.dialog_.onclose(closeEvent);
+      }
+
+      // Dispatch the event as normal
       this.dialog_.dispatchEvent(closeEvent);
+
     }
 
   };


### PR DESCRIPTION
Some existing browser implementations of `HTMLDialogelement` already handle the `onclose` property. Since `onclose` defines a single handler, it is extremely useful when reusing dialogs, as opposed to `addEventListener()`, where there is no ready or easy or clean way to clear any existing handlers. With `onclose`, a dialog element can be used as a template and just have `onclose` assigned to whatever handler if and when necessary.