### PR TITLE
Forward mouseup and mousedown too.

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,9 @@ function dialogPolyfillInfo(dialog) {
 
   this.backdrop_ = document.createElement('div');
   this.backdrop_.className = 'backdrop';
-  this.backdrop_.addEventListener('click', this.backdropClick_.bind(this));
+  this.backdrop_.addEventListener('mouseup'  , this.backdropMouseEvent_.bind(this));
+  this.backdrop_.addEventListener('mousedown', this.backdropMouseEvent_.bind(this));
+  this.backdrop_.addEventListener('click'    , this.backdropMouseEvent_.bind(this));
 }
 
 dialogPolyfillInfo.prototype = /** @type {HTMLDialogElement.prototype} */ ({
@@ -247,12 +249,12 @@ dialogPolyfillInfo.prototype = /** @type {HTMLDialogElement.prototype} */ ({
   },
 
   /**
-   * Handles clicks on the fake .backdrop element, redirecting them as if
+   * Handles mouse events ('mouseup', 'mousedown', 'click') on the fake .backdrop element, redirecting them as if
    * they were on the dialog itself.
    *
    * @param {!Event} e to redirect
    */
-  backdropClick_: function(e) {
+  backdropMouseEvent_: function(e) {
     if (!this.dialog_.hasAttribute('tabindex')) {
       // Clicking on the backdrop should move the implicit cursor, even if dialog cannot be
       // focused. Create a fake thing to focus on. If the backdrop was _before_ the dialog, this


### PR DESCRIPTION
In my application, I detect clicks on the backdrop by comparing the `MouseEvent`'s x and y coordinates to the dialog's box dimensions and closing the dialog if the user clicked on the backdrop.

However I can't simply use the 'click' event because my dialogs are resizable (using the browser native resize grip in the bottom-right corner of the dialog). If a user drags the resize handle to make the dialog bigger - and if the dialog has a `max-width` and/or `max-height` and the user keeps on dragging the mouse cursor and releases their mouse button over the backdrop then the 'click' event is raised with the `MouseEvent` coordinates over the backdrop - so I use the mouseup and mousedown events to detect if the mouse moved between the backdrop and the dialog-proper (again, by comparing coordinates of the MouseEvent with the size of the dialog-proper), and based on that it either ignores the click or it closes the dialog.

My solution works with this Polyfill library, but I first needed to invoke the `backdropClick_` function for `mouseup` and `mousedown` events - so this is me contributing those trivial changes back.