### PR TITLE
Use SPDX identifier at license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleChrome/dialog-polyfill.git"
   },
   "author": "The Chromium Authors",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "homepage": "https://github.com/GoogleChrome/dialog-polyfill",
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
It is recommended to use the SPDX license identifier for the `license` field in package.json.
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license

Automatic license checkers such as [`license-checker-webpack-plugin`](https://github.com/microsoft/license-checker-webpack-plugin) accepts only SPDX license identifiers and some well-known format as a valid license.
With this change, these tools can handle this package correctly.

