### PR TITLE
Fix findNearestDialog for child of slotted element

### DIFF
--- a/dist/dialog-polyfill.esm.js
+++ b/dist/dialog-polyfill.esm.js
@@ -64,7 +64,9 @@ function findNearestDialog(el) {
     if (el.localName === 'dialog') {
       return /** @type {HTMLDialogElement} */ (el);
     }
-    if (el.parentElement) {
+    if (el.assignedSlot) {
+      el = el.assignedSlot;
+    } else if (el.parentElement) {
       el = el.parentElement;
     } else if (el.parentNode) {
       el = el.parentNode.host;

--- a/dist/dialog-polyfill.js
+++ b/dist/dialog-polyfill.js
@@ -70,7 +70,9 @@
       if (el.localName === 'dialog') {
         return /** @type {HTMLDialogElement} */ (el);
       }
-      if (el.parentElement) {
+      if (el.assignedSlot) {
+        el = el.assignedSlot;
+      } else if (el.parentElement) {
         el = el.parentElement;
       } else if (el.parentNode) {
         el = el.parentNode.host;

--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ function findNearestDialog(el) {
     if (el.localName === 'dialog') {
       return /** @type {HTMLDialogElement} */ (el);
     }
-    if (el.parentElement) {
+    if (el.assignedSlot) {
+      el = el.assignedSlot;
+    } else if (el.parentElement) {
       el = el.parentElement;
     } else if (el.parentNode) {
       el = el.parentNode.host;


### PR DESCRIPTION
Fix for issue #217.

A focus event for an element which is a child of a slotted element
will be erroneously reported as not in the topmost dialog. This is
because for the slotted element we should follow assignedSlot rather
than the parentElement or parentNode to get the true hierarchy in
which the elmeent lives. This change adds handling for slotted
elements.