### PR TITLE
Add existing focusable elements to correctly manage tab key navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function isFormMethodDialog(el) {
 function findFocusableElementWithin(hostElement) {
   // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
   // alternative involves stepping through and trying to focus everything.
-  var opts = ['button', 'input', 'keygen', 'select', 'textarea'];
+  var opts = ['button', 'input', 'keygen', 'select', 'textarea', 'a[href]', 'area[href]', 'iframe', 'object', 'embed'];
   var query = opts.map(function(el) {
     return el + ':not([disabled])';
   });

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function isFormMethodDialog(el) {
 function findFocusableElementWithin(hostElement) {
   // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
   // alternative involves stepping through and trying to focus everything.
-  var opts = ['button', 'input', 'keygen', 'select', 'textarea', 'a[href]', 'area[href]', 'iframe', 'object', 'embed'];
+  var opts = ['button', 'input', 'keygen', 'select', 'textarea', 'a[href]', 'area[href]', 'iframe', 'object', 'embed', '[contenteditable]'];
   var query = opts.map(function(el) {
     return el + ':not([disabled])';
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dialog-polyfill",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
More elements are needed to correctly manage tab key navigation. This PR adds elements that may receive focus when tabbing.

Especially the `<a>` element seems important to include here. But the others may receive focus as well.