### PR TITLE
Declare SPDX-compatible BSD-3-Clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/GoogleChrome/dialog-polyfill.git"
   },
   "author": "The Chromium Authors",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "homepage": "https://github.com/GoogleChrome/dialog-polyfill",
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
# What this brings 

This PR changes the declared license in the package's metadata.

# What's the problem and what's the fix?

`BSD` is no SPDX-compatible identifier for licenses (see [the list](https://spdx.org/licenses/)).
It is a problem since automated tools will not be able to detect which license this package actually is under.
Using `BSD-3-Clause` allows license checker tools to properly classify this package